### PR TITLE
feat(membership): wire Apply button to CMS-managed form link

### DIFF
--- a/app/[locale]/(site)/membership/page.tsx
+++ b/app/[locale]/(site)/membership/page.tsx
@@ -39,6 +39,7 @@ import {
   fetchMemberTypes,
   fetchQuestions,
 } from "@/lib/membership-data";
+import { getApplyLink } from "@/lib/apply-data";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -65,11 +66,12 @@ export default async function MembershipPage({ params }: PageProps) {
   if (!isValidLocale(locale)) notFound();
   const dict = getDictionary(locale as Locale);
 
-  const [apiBenefits, apiHowToJoins, apiMemberTypes, apiQuestions] = await Promise.all([
+  const [apiBenefits, apiHowToJoins, apiMemberTypes, apiQuestions, applyUrl] = await Promise.all([
     fetchBenefits(locale),
     fetchHowToJoins(locale),
     fetchMemberTypes(locale),
     fetchQuestions(locale),
+    getApplyLink(locale),
   ]);
 
   const finalBenefits = apiBenefits.length > 0
@@ -354,10 +356,17 @@ export default async function MembershipPage({ params }: PageProps) {
             asChild
             className="bg-accent text-accent-foreground hover:bg-accent/90"
           >
-            <Link href={`/${locale}/contact`}>
-              {dict.membership.ctaButton}
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
+            {applyUrl ? (
+              <a href={applyUrl} target="_blank" rel="noopener noreferrer">
+                {dict.membership.ctaButton}
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </a>
+            ) : (
+              <Link href={`/${locale}/contact`}>
+                {dict.membership.ctaButton}
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            )}
           </Button>
         </section>
       </div>

--- a/lib/apply-data.ts
+++ b/lib/apply-data.ts
@@ -1,0 +1,23 @@
+const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
+
+/**
+ * Returns the external membership application form URL (e.g. JotForm) configured
+ * in the CMS "Membership — Apply Link" single type, or null when it is not set /
+ * unavailable — in which case callers should fall back to the internal route.
+ */
+export async function getApplyLink(locale: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${BASE_URL}/api/membership-apply?locale=${locale}`, {
+      next: { revalidate: 0 },
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    const url = json?.data?.form_url;
+    if (typeof url !== "string") return null;
+    const trimmed = url.trim();
+    return /^https?:\/\//i.test(trimmed) ? trimmed : null;
+  } catch (error) {
+    console.error("Error fetching membership apply link:", error);
+    return null;
+  }
+}


### PR DESCRIPTION
## What
ทำให้ปุ่ม **"สมัครสมาชิกเลย"** ท้ายหน้า Membership ลิงก์ไปฟอร์ม JotForm
โดยดึง URL จาก CMS (single type "Membership — Apply Link")

## Changes
- 🆕 `lib/apply-data.ts` — `getApplyLink()` ดึง `form_url` จาก Strapi
- ✏️ `app/[locale]/(site)/membership/page.tsx` — ปุ่ม CTA:
  - มี URL → เปิด JotForm **แท็บใหม่** (`target="_blank"` + `rel="noopener noreferrer"`)
  - ไม่มี/ดึงไม่ได้ → fallback ไป `/contact` (พฤติกรรมเดิม)

## How to test
1. รัน CMS (มี single type membership-apply แล้ว) + `pnpm dev`
2. เปิด `/th/membership` — ปุ่มยัง fallback ไป `/contact` ถ้ายังไม่ตั้ง URL
3. ใน Strapi admin ตั้ง `form_url` แล้ว Publish → reload → ปุ่มพาไป JotForm (แท็บใหม่)

## Depends on
- Nadhsikarn/ECTI-cms#18 — ต้อง merge/deploy ก่อน

Closes #23