### PR TITLE
feat(footer): pull social links from CMS; use X logo, add YouTube

### DIFF
--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,15 +1,27 @@
 import Image from "next/image";
 import Link from "next/link";
-import { Facebook, Twitter, Linkedin, Mail } from "lucide-react";
+import { Facebook, Linkedin, Youtube } from "lucide-react";
 import type { Dictionary, Locale } from "@/lib/i18n";
+import { getSocialLinks } from "@/lib/social-data";
 
 interface SiteFooterProps {
   locale: Locale;
   dict: Dictionary;
 }
 
-export function SiteFooter({ locale, dict }: SiteFooterProps) {
+// X (formerly Twitter) brand logo — lucide's `X` is a close/cross icon, not the
+// brand mark, so we inline the official logo here.
+function XIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+export async function SiteFooter({ locale, dict }: SiteFooterProps) {
   const currentYear = new Date().getFullYear();
+  const social = await getSocialLinks(locale);
 
   const quickLinksCol1 = [
     { label: dict.nav.home, href: `/${locale}` },
@@ -25,28 +37,21 @@ export function SiteFooter({ locale, dict }: SiteFooterProps) {
     { label: dict.nav.contact, href: `/${locale}/contact` },
   ];
 
-  const socialLinks = [
-    {
-      label: "Facebook",
-      href: "https://facebook.com/ecaboratory",
-      icon: Facebook,
-    },
-    {
-      label: "Twitter",
-      href: "https://twitter.com/ecti",
-      icon: Twitter,
-    },
-    {
-      label: "LinkedIn",
-      href: "https://linkedin.com/company/ecti",
-      icon: Linkedin,
-    },
-    {
-      label: "Email",
-      href: "mailto:info@ecti.or.th",
-      icon: Mail,
-    },
+  type FooterIcon = React.ComponentType<{
+    className?: string;
+    "aria-hidden"?: boolean | "true" | "false";
+  }>;
+
+  const allSocial: { label: string; href: string | null; icon: FooterIcon }[] = [
+    { label: "Facebook", href: social.facebook, icon: Facebook },
+    { label: "X", href: social.x, icon: XIcon },
+    { label: "LinkedIn", href: social.linkedin, icon: Linkedin },
+    { label: "YouTube", href: social.youtube, icon: Youtube },
   ];
+
+  const socialLinks = allSocial.filter(
+    (s): s is { label: string; href: string; icon: FooterIcon } => Boolean(s.href)
+  );
 
   return (
     <footer className="border-t border-border bg-primary text-primary-foreground" role="contentinfo">
@@ -108,16 +113,16 @@ export function SiteFooter({ locale, dict }: SiteFooterProps) {
               {dict.footer.followUs}
             </h3>
             <div className="flex items-center gap-2">
-              {socialLinks.map((social) => (
+              {socialLinks.map((item) => (
                 <a
-                  key={social.label}
-                  href={social.href}
+                  key={item.label}
+                  href={item.href}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary-foreground/10 text-primary-foreground/60 transition-colors hover:bg-primary-foreground/20 hover:text-primary-foreground focus-visible:bg-primary-foreground/20 focus-visible:text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-foreground/30"
-                  aria-label={social.label}
+                  aria-label={item.label}
                 >
-                  <social.icon className="h-4 w-4" aria-hidden="true" />
+                  <item.icon className="h-4 w-4" aria-hidden="true" />
                 </a>
               ))}
             </div>

--- a/lib/social-data.ts
+++ b/lib/social-data.ts
@@ -1,0 +1,42 @@
+const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
+
+export interface SocialLinks {
+  facebook: string | null;
+  x: string | null;
+  linkedin: string | null;
+  youtube: string | null;
+}
+
+const EMPTY: SocialLinks = { facebook: null, x: null, linkedin: null, youtube: null };
+
+function clean(url: unknown): string | null {
+  if (typeof url !== "string") return null;
+  const trimmed = url.trim();
+  return /^https?:\/\//i.test(trimmed) ? trimmed : null;
+}
+
+/**
+ * Reads the social media profile URLs from the CMS "Social Links" single type.
+ * Any field that is unset/invalid comes back as null so the footer can hide that
+ * icon; on error every field is null (footer simply shows no social icons).
+ */
+export async function getSocialLinks(locale: string): Promise<SocialLinks> {
+  try {
+    const res = await fetch(`${BASE_URL}/api/social-link?locale=${locale}`, {
+      next: { revalidate: 0 },
+    });
+    if (!res.ok) return EMPTY;
+    const json = await res.json();
+    const d = json?.data;
+    if (!d) return EMPTY;
+    return {
+      facebook: clean(d.facebook_url),
+      x: clean(d.x_url),
+      linkedin: clean(d.linkedin_url),
+      youtube: clean(d.youtube_url),
+    };
+  } catch (error) {
+    console.error("Error fetching social links:", error);
+    return EMPTY;
+  }
+}


### PR DESCRIPTION
## ทำอะไรไป
เปลี่ยน social media icons ที่ footer จากที่ **hardcode** ในโค้ด ให้ **ดึงจาก CMS**
(single type "Social Links") แทน + ปรับชุดไอคอนตามที่อาจารย์ต้องการ

## เปลี่ยนอะไรบ้าง
- 🆕 `lib/social-data.ts` — `getSocialLinks()` ดึงลิงก์จาก Strapi
- ✏️ `components/site-footer.tsx`:
  - footer เป็น async component ดึง social จาก CMS แทน array ที่ hardcode
  - **เปลี่ยนไอคอน Twitter (นกตัวเก่า) → โลโก้ X ตัวปัจจุบัน** (custom SVG เพราะ
    `X` ของ lucide เป็นไอคอนกากบาทปิด ไม่ใช่โลโก้แบรนด์)
  - **เปลี่ยนไอคอน Email/mailto → YouTube**
  - ไอคอนไหน URL ว่าง → **ซ่อนอัตโนมัติ**
  - ถ้าดึง CMS ไม่ได้ → footer ไม่พัง (แค่ไม่โชว์ไอคอน social)

## วิธีเทสต์
1. รัน CMS (มี single type social-link แล้ว) + `pnpm dev`
2. เปิดหน้าไหนก็ได้ เลื่อนลงดู footer → เห็นไอคอน Facebook / X / LinkedIn
3. ไปตั้ง `youtube_url` ใน Strapi → reload → ไอคอน YouTube โผล่เพิ่ม
4. ลบค่า field ไหนออก → ไอคอนนั้นหายไป

## Depends on
- Nadhsikarn/ECTI-cms#19 — ต้อง merge/deploy ก่อน

Closes #33