### PR TITLE
feat: make events Details button link to external event site

### DIFF
--- a/components/events-list-client.tsx
+++ b/components/events-list-client.tsx
@@ -9,7 +9,6 @@ import {
   X,
   ArrowRight,
   Clock,
-  CalendarCheck,
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -408,20 +407,16 @@ function EventCard({
         )}
 
         {/* Actions */}
-        <div className="flex flex-wrap items-center gap-2 pt-1">
-          <Button variant="outline" size="sm" className="gap-1.5" disabled>
-            {dict.events.btnDetails}
-            <ArrowRight className="h-3.5 w-3.5" />
-          </Button>
-          {event.register_url && event.status !== "finished" && (
+        {event.register_url && (
+          <div className="flex flex-wrap items-center gap-2 pt-1">
             <a href={event.register_url} target="_blank" rel="noopener noreferrer">
-              <Button size="sm" className={`gap-1.5 ${event.status === "open" ? "bg-red-600 hover:bg-red-700 text-white" : ""}`}>
-                <CalendarCheck className="h-3.5 w-3.5" />
-                {event.status === "open" ? dict.events.btnSubmitPaper : dict.events.btnRegister}
+              <Button variant="outline" size="sm" className="gap-1.5">
+                {dict.events.btnDetails}
+                <ArrowRight className="h-3.5 w-3.5" />
               </Button>
             </a>
-          )}
-        </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Replace the disabled Details button with an external link using the event's register_url, and remove the Register/Submit Paper button. Events without a URL now show no action button at all.

เนื้อหา:
## สรุปการแก้ไข
- เหลือปุ่มเดียวในการ์ด event คือปุ่ม "รายละเอียด" ซึ่ง link ออกไปเว็บไซต์ของงาน (เปิดแท็บใหม่)
- ลบปุ่ม "ลงทะเบียน / ส่งบทความ" ออก
- ถ้า event ไหนไม่มี link ปุ่มจะถูกซ่อน ไม่แสดงปุ่ม disabled ค้างไว้แบบเดิม

## ฝั่ง CMS
ไม่ต้องแก้ schema — ใช้ field `register_url` เดิม โดยตอนเพิ่มข้อมูลให้ใส่ลิงก์เว็บไซต์ของงานลงใน field นี้แทน

## การทดสอบ
เช็คหน้า `/th/events` กับ dev server แล้ว: event ที่มี URL แสดงปุ่มรายละเอียดชี้ไปเว็บนอกถูกต้อง ส่วน event ที่ไม่มี URL ไม่แสดงปุ่ม

Closes #25