### PR TITLE
feat: replace proceedings section with regular conferences on Publications

### DIFF
--- a/app/[locale]/(site)/publications/page.tsx
+++ b/app/[locale]/(site)/publications/page.tsx
@@ -3,9 +3,11 @@ import type { Locale } from "@/lib/i18n";
 import { notFound } from "next/navigation";
 import { PageHeader } from "@/components/page-header";
 import { Card, CardContent } from "@/components/ui/card";
-import { BookOpen, FileText, ExternalLink } from "lucide-react";
+import { BookOpen, CalendarDays, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { getJournals } from "@/lib/publications-data";
+import { getConferences } from "@/lib/conferences-data";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -33,6 +35,7 @@ export default async function PublicationsPage({ params }: PageProps) {
   const dict = getDictionary(locale as Locale);
 
   const journals = await getJournals(locale);
+  const conferences = await getConferences(locale);
 
   return (
     <>
@@ -86,20 +89,45 @@ export default async function PublicationsPage({ params }: PageProps) {
           ))}
         </div>
 
-        {/* Proceedings */}
-        <h2 className="mb-8 text-2xl font-bold text-foreground">
-          {dict.publications.proceedingsTitle}
-        </h2>
-        <Card className="border-border">
-          <CardContent className="flex flex-col gap-4 p-6 md:flex-row md:items-center md:gap-8">
-            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-accent/10">
-              <FileText className="h-7 w-7 text-accent" />
+        {/* Conferences */}
+        {conferences.length > 0 && (
+          <>
+            <h2 className="mb-8 text-2xl font-bold text-foreground">
+              {dict.publications.conferencesTitle}
+            </h2>
+            <div className="flex flex-col gap-6">
+              {conferences.map((conf) => (
+                <Card key={conf.id} className="border-border">
+                  <CardContent className="flex flex-col gap-4 p-6 md:flex-row md:items-start md:gap-8">
+                    <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-accent/10">
+                      <CalendarDays className="h-7 w-7 text-accent" />
+                    </div>
+                    <div className="flex flex-col gap-3">
+                      <h3 className="text-lg font-semibold text-card-foreground">
+                        {conf.title}
+                      </h3>
+                      <p className="whitespace-pre-line leading-relaxed text-muted-foreground">
+                        {conf.description}
+                      </p>
+                      {conf.years.length > 0 && (
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <span className="text-xs font-medium text-muted-foreground">
+                            {dict.publications.conferencesYearsLabel}:
+                          </span>
+                          {conf.years.map((year) => (
+                            <Badge key={year} variant="secondary" className="font-normal">
+                              {year}
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
             </div>
-            <p className="leading-relaxed text-muted-foreground">
-              {dict.publications.proceedingsText}
-            </p>
-          </CardContent>
-        </Card>
+          </>
+        )}
       </div>
     </>
   );

--- a/lib/conferences-data.ts
+++ b/lib/conferences-data.ts
@@ -1,0 +1,26 @@
+const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
+
+export interface Conference {
+  id: number;
+  title: string;
+  description: string;
+  years: string[];
+}
+
+export async function getConferences(locale: string): Promise<Conference[]> {
+  const res = await fetch(
+    `${BASE_URL}/api/conferences?sort=order:asc&locale=${locale}`,
+    { next: { revalidate: 0 } }
+  );
+  if (!res.ok) return [];
+  const json = await res.json();
+  return json.data.map((item: any) => ({
+    id: item.id,
+    title: item.title ?? "",
+    description: item.description ?? "",
+    years: (item.years ?? "")
+      .split(",")
+      .map((y: string) => y.trim())
+      .filter(Boolean),
+  }));
+}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -288,8 +288,8 @@ const dictionaries = {
       journalCITDesc:"วารสารที่ครอบคลุมงานวิจัยด้านวิทยาการคอมพิวเตอร์และเทคโนโลยีสารสนเทศ",
       journalARD: "ECTI Journal on Applied Research and Development (ECTI-ARD)",
       journalARDDesc:"วารสารที่ครอบคลุมงานวิจัยด้านการประยุกต์ใช้เทคโนโลยีวิศวกรรมไฟฟ้า อิเล็กทรอนิกส์ คอมพิวเตอร์ และสารสนเทศ เพื่อนำไปสู่นวัตกรรมที่เป็นประโยชน์",
-      proceedingsTitle: "เอกสารการประชุมวิชาการ",
-      proceedingsText:"รวบรวมบทความวิจัยจากการประชุมวิชาการ ECTI-CON และงานประชุมอื่นๆ ที่จัดโดยสมาคม",
+      conferencesTitle: "งานประชุมวิชาการที่จัดเป็นประจำ",
+      conferencesYearsLabel: "ปีที่จัด",
     },
     resources: {
       title: "แหล่งข้อมูล",
@@ -606,9 +606,8 @@ const dictionaries = {
       journalARD: "ECTI Journal on Applied Research and Development (ECTI-ARD)",
       journalARDDesc:
         "A journal covering applied research in electrical engineering, electronics, computer, and information technology, driving innovation for practical benefit.",
-      proceedingsTitle: "Conference Proceedings",
-      proceedingsText:
-        "Collection of research papers from ECTI-CON and other conferences organized by the association.",
+      conferencesTitle: "Our Regular Conferences",
+      conferencesYearsLabel: "Years held",
     },
     resources: {
       title: "Resources",


### PR DESCRIPTION
## สรุป
ตาม #27 — ตัด section "เอกสารการประชุมวิชาการ" (proceedings) ออก
แล้วเพิ่ม section "งานประชุมวิชาการที่จัดเป็นประจำ" ที่ดึงข้อมูลจาก CMS

## การเปลี่ยนแปลง
- เพิ่ม `lib/conferences-data.ts` → `getConferences()` ดึงจาก CMS
- หน้า Publications: ลบกล่อง proceedings เดิม + เพิ่ม section การ์ดกล่องยาว
  แต่ละงานแสดง ชื่อ + ความเป็นมาเต็ม + แถวป้าย "ปีที่จัด"
- i18n: เปลี่ยน `proceedings*` → `conferencesTitle` + เพิ่ม `conferencesYearsLabel` (th/en)
- ซ่อน section อัตโนมัติถ้าไม่มีข้อมูลจาก CMS

## ต้องมี
ต้อง merge CMS PR (collection `conference`) ก่อน ข้อมูลถึงจะขึ้น

Closes #27