### PR TITLE
fix(events): show the event end date on the events pages

### DIFF
--- a/lib/events-data.ts
+++ b/lib/events-data.ts
@@ -54,7 +54,7 @@ export async function fetchEventBySlug(slug: string, locale: string) {
   return {
     slug: attr.slug ?? item.id.toString(),
     title: attr.title,
-    date: formatDate(attr.event_start_date, locale),
+    date: formatDateRange(attr.event_start_date, attr.event_end_date, locale),
     location: attr.location ?? "",
     description: attr.description?.[0]?.children?.[0]?.text || "",
     overview: "",
@@ -93,7 +93,7 @@ export async function fetchEventsFromAPI(locale: string): Promise<ECTIEvent[]> {
     return {
       slug: attr.slug ?? item.id.toString(),
       title: attr.title,
-      date: formatDate(attr.event_start_date, locale),
+      date: formatDateRange(attr.event_start_date, attr.event_end_date, locale),
       location: attr.location ?? "",
       description: attr.description?.[0]?.children?.[0]?.text || "",
       overview: "",


### PR DESCRIPTION
สำหรับแสดงผลอยู่แล้ว (ข้อมูล fallback เดิมในไฟล์ก็เก็บเป็น `"9-12 กรกฎาคม 2569"`
คือตั้งใจให้เก็บช่วงวันตั้งแต่แรก)

`formatDateRange` จัดการเคสงานวันเดียวไว้แล้ว (`if (!end || end === start)`)
เพราะงั้นกิจกรรมที่ไม่ได้กรอกวันจบ หรือกรอกวันจบเท่ากับวันเริ่ม จะยังแสดงวันเดียว
เหมือนเดิม ไม่มี dash ห้อยท้าย

### วิธีทดสอบ (Testing Instructions)
1. รัน Strapi (`:1337`) + `pnpm dev`
2. เปิด `/th/events` และ `/en/events` — กิจกรรมที่กรอก `event_end_date` ไว้
   ต้องขึ้นเป็นช่วง เช่น "9 กรกฎาคม 2569 – 12 กรกฎาคม 2569"
3. เปิดกิจกรรมรายตัว — วันที่ต้องตรงกับที่แสดงในหน้า list
4. เทียบกับ section กิจกรรมเด่นหน้าแรก — ต้องแสดงเหมือนกันแล้ว
5. กิจกรรมที่ไม่ได้กรอกวันจบต้องยังขึ้นวันเดียวตามปกติ