### PR TITLE
fix(events): sort the events list by start date, newest first

### DIFF
--- a/lib/events-data.ts
+++ b/lib/events-data.ts
@@ -74,9 +74,11 @@ export async function fetchEventBySlug(slug: string, locale: string) {
 }
 
 // func fetch
+// Ordered newest-first here rather than in the client: EventsListClient re-sorts
+// by status with a stable sort, so this date order survives within each status group.
 export async function fetchEventsFromAPI(locale: string): Promise<ECTIEvent[]> {
   const res = await fetch(
-    `${API_URL}?populate=*&locale=${locale}`,
+    `${API_URL}?populate=*&sort=event_start_date:desc&locale=${locale}`,
     { cache: "no-store" }
   );
 


### PR DESCRIPTION
Closes #43 

## ปัญหา

Activity ที่เพิ่งเพิ่มเข้าไปใหม่ โผล่ผิดตำแหน่งบนหน้า `/events` — ECTI-CON 2022 ขึ้นมาอยู่เหนือ card ปี 2023 ทั้งสองใบ

## สาเหตุ

เกิดจากสองอย่างซ้อนกัน:

1. `fetchEventsFromAPI` (`lib/events-data.ts`) ยิง activities endpoint โดยไม่ส่ง `sort` param เลย Strapi เลยคืนข้อมูลมาตามลำดับของ database ซึ่งไม่การันตีอะไร พอเพิ่ม record ใหม่ลำดับก็สลับได้ และ schema เองก็ไม่ได้ตั้ง default sort ไว้
2. sort ตัวเดียวที่ทำงานจริงอยู่ฝั่ง client ใน `events-list-client.tsx` ซึ่งเรียงตาม `STATUS_ORDER` อย่างเดียว ไม่มี tiebreak ด้วยวันที่ และเพราะ `Array.sort` เป็น stable sort event ที่ status เหมือนกันจึงคงลำดับที่ API ส่งมา

ข้อมูลจริงบน production ทุก activity เป็น `finished` หมด status sort เลยแทบไม่ได้ขยับอะไร ลำดับบนหน้าเว็บจึงเท่ากับลำดับมั่ว ๆ ที่ API ส่งมาตรง ๆ

ส่วน `getFeaturedEvents` ของหน้าแรกส่ง `sort=event_start_date:desc` อยู่แล้ว หน้าแรกเลยไม่มีปัญหา ทำให้บั๊กนี้รอดสายตามาตลอด

## การแก้

ส่ง `sort=event_start_date:desc` ตอน fetch จากนั้น stable status sort จะรักษาลำดับวันที่ไว้ให้เองภายในแต่ละกลุ่ม status โดยไม่ต้องแก้ฝั่ง client เลย และการ sort ที่ฝั่ง server ยังทำให้สอดคล้องกับ `getFeaturedEvents` ด้วย

แก้เฉพาะฝั่ง front — schema และ API ของ Strapi รองรับอยู่แล้ว ไม่ต้องแตะ CMS

## การทดสอบ

ยิงทั้งสอง query เทียบกับ Strapi Cloud ของจริง:

| query | ลำดับที่ได้ |
|---|---|
| ก่อนแก้ | **ECTI-CON2022** → ECTI-CARD2023 → ICA-SYMP 2023 → ECTI-CON 2018 → ITC-CSCC 2018 → **ISCIT 2018** |
| หลังแก้ | ECTI-CARD2023 → ICA-SYMP 2023 → **ECTI-CON2022** → **ISCIT 2018** → ECTI-CON 2018 → ITC-CSCC 2018 |

repro ตรงกับที่รายงานเป๊ะ และการแก้นี้ยังไปแก้ตำแหน่งของ ISCIT 2018 ที่เดิมก็ผิดอยู่ในกลุ่มปี 2018 ให้ถูกต้องไปด้วย

หมายเหตุ: บั๊กนี้ repro บน localhost ไม่ได้ เพราะ `.env.local` ชี้ไป Strapi local ซึ่งมีข้อมูลคนละชุดกัน

## ขอบเขต

PR นี้จัดลำดับ event *ภายในกลุ่ม status เดียวกัน* เท่านั้น status ยังเป็น sort key หลักอยู่ event ที่เป็น `open`/`register` จึงยังลอยอยู่เหนือ event ที่ `finished` เสมอไม่ว่าวันที่จะเก่ากว่าก็ตาม — อันนี้เป็นพฤติกรรมเดิมที่ตั้งใจไว้ และ PR นี้ไม่ได้เปลี่ยน