### PR TITLE
fix(events): label each filter box in its trigger

### DIFF
--- a/components/events-list-client.tsx
+++ b/components/events-list-client.tsx
@@ -72,6 +72,20 @@ function getTypeLabel(type: EventType, dict: Dictionary): string {
   return map[type];
 }
 
+// Every filter defaults to "all", so SelectValue's placeholder never renders and
+// each trigger would just read "ทั้งหมด". Pass the label through as children
+// instead, which Radix renders in place of the selected item's text. Keep this a
+// direct child of SelectTrigger — the trigger styles the select-value slot with
+// direct-child selectors.
+function FilterValue({ label, value }: { label: string; value: string }) {
+  return (
+    <SelectValue>
+      <span className="text-muted-foreground">{label}:</span>
+      {value}
+    </SelectValue>
+  );
+}
+
 export function EventsListClient({
   locale,
   dict,
@@ -155,8 +169,11 @@ export function EventsListClient({
         <div className="flex flex-wrap items-center gap-3">
           {/* Year */}
           <Select value={yearFilter} onValueChange={setYearFilter}>
-            <SelectTrigger className="w-[130px]">
-              <SelectValue placeholder={dict.events.filterYear} />
+            <SelectTrigger className="w-[150px]">
+              <FilterValue
+                label={dict.events.filterYear}
+                value={yearFilter === "all" ? dict.events.filterAll : yearFilter}
+              />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">{dict.events.filterAll}</SelectItem>
@@ -170,8 +187,15 @@ export function EventsListClient({
 
           {/* Type */}
           <Select value={typeFilter} onValueChange={setTypeFilter}>
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder={dict.events.filterType} />
+            <SelectTrigger className="w-[250px]">
+              <FilterValue
+                label={dict.events.filterType}
+                value={
+                  typeFilter === "all"
+                    ? dict.events.filterAll
+                    : getTypeLabel(typeFilter as EventType, dict)
+                }
+              />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">{dict.events.filterAll}</SelectItem>
@@ -183,8 +207,15 @@ export function EventsListClient({
 
           {/* Status */}
           <Select value={statusFilter} onValueChange={setStatusFilter}>
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder={dict.events.filterStatus} />
+            <SelectTrigger className="w-[210px]">
+              <FilterValue
+                label={dict.events.filterStatus}
+                value={
+                  statusFilter === "all"
+                    ? dict.events.filterAll
+                    : getStatusLabel(statusFilter as EventStatus, dict)
+                }
+              />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">{dict.events.filterAll}</SelectItem>
@@ -197,8 +228,13 @@ export function EventsListClient({
 
           {/* Location */}
           <Select value={locationFilter} onValueChange={setLocationFilter}>
-            <SelectTrigger className="w-[240px]">
-              <SelectValue placeholder={dict.events.filterLocation} />
+            <SelectTrigger className="w-[280px]">
+              <FilterValue
+                label={dict.events.filterLocation}
+                value={
+                  locationFilter === "all" ? dict.events.filterAll : locationFilter
+                }
+              />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">{dict.events.filterAll}</SelectItem>


### PR DESCRIPTION
Closes #26

## ปัญหา

กล่อง filter บนหน้า `/events` ทั้ง 4 ตัวขึ้นคำว่า "ทั้งหมด" เหมือนกันหมด แยกไม่ออกว่ากล่องไหนกรองปี กล่องไหนกรองประเภท

## สาเหตุ

ทุก filter ส่ง label ของตัวเองเข้าไปเป็น `placeholder` ของ `SelectValue`:

```tsx
<Select value={yearFilter} onValueChange={setYearFilter}>   // useState("all")
  <SelectTrigger><SelectValue placeholder={dict.events.filterYear} /></SelectTrigger>

แต่ Radix จะ render placeholder เฉพาะตอนที่ value ยังว่าง เท่านั้น พอทุก filter มีค่า default เป็น "all" ซึ่งไม่เคยว่างเลย placeholder จึงไม่มีทางถูกแสดง มันเลยไป render ข้อความของ item ที่เลือกอยู่แทน ซึ่งก็คือ filterAll = "ทั้งหมด" ทั้ง 4 กล่อง

string ปี / ประเภท / สถานะ / สถานที่ มีครบอยู่แล้วใน lib/i18n.ts แค่ไม่เคยได้ออกจอ

การแก้

ส่ง label เข้าไปเป็น children ของ SelectValue ซึ่ง Radix จะ render แทนข้อความของ item ที่เลือก ทำให้ label โผล่เสมอไม่ว่า value จะเป็นอะไร

เลือกวิธีนี้แทนการแปะ <span> ไว้ข้าง ๆ SelectValue เพราะ SelectTrigger มี justify-between อยู่ ถ้าเพิ่ม child เข้าไปตรง ๆ label กับ value จะถูกดันแยกคนละมุมกล่อง และ CSS ของ trigger ยังผูกกับ data-slot=select-value ผ่าน direct-child selector ด้วย การยัดไว้ใน SelectValue จึงไม่กระทบโครงสร้างเดิมเลย

รวม logic ไว้ใน component FilterValue ตัวเดียวให้ทั้ง 4 กล่องใช้ร่วมกัน และใช้ getTypeLabel / getStatusLabel ที่มีอยู่แล้วต่อ

ขยายความกว้าง trigger ให้พอดีกับ option ที่ยาวที่สุดในภาษาไทย (ตัวที่คับสุดคือ "ประเภท: สัมมนาเชิงปฏิบัติการ"):

┌────────┬───────┬───────┐
│ filter │  เดิม  │  ใหม่  │
├────────┼───────┼───────┤
│ ปี      │ 130px │ 150px │
├────────┼───────┼───────┤
│ ประเภท │ 180px │ 250px │
├────────┼───────┼───────┤
│ สถานะ  │ 180px │ 210px │
├────────┼───────┼───────┤
│ สถานที่  │ 240px │ 280px │
└────────┴───────┴───────┘

การทดสอบ

ดูจาก HTML ที่ render จริงทั้งสอง locale:

┌─────┬──────────────────────────────────────────────────────┬────────────────────────────────────────────────────┐
│     │                         ไทย                          │                       อังกฤษ                        │
├─────┼──────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ ก่อน │ ทั้งหมด / ทั้งหมด / ทั้งหมด / ทั้งหมด                        │ All / All / All / All                              │
├─────┼──────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ หลัง │ ปี: ทั้งหมด / ประเภท: ทั้งหมด / สถานะ: ทั้งหมด / สถานที่:     │ Year: All / Type: All / Status: All / Location:    │
│     │ ทั้งหมด                                                │ All                                                │
└─────┴──────────────────────────────────────────────────────┴────────────────────────────────────────────────────┘

tsc --noEmit ผ่าน

จุดที่อยากให้ช่วยดูตอน review

ตัวเลขความกว้างมาจากการกะจากความยาวข้อความ ยังไม่ได้วัดจากของจริง รบกวนช่วยดูว่าตัวหนังสือไม่ล้น/ไม่โดนตัด โดยเฉพาะตอนเลือก "ประเภท → สัมมนาเชิงปฏิบัติการ" และดูว่าแถว filter บนจอมือถือ wrap แล้วยังโอเคอยู่ไหม เพราะความกว้างรวมเพิ่มจากเดิมประมาณ 140px