### PR TITLE
fix(about): page through all board members instead of one 100-row page

### DIFF
--- a/lib/about-data.ts
+++ b/lib/about-data.ts
@@ -9,17 +9,17 @@ export interface BoardMember {
   image: { url: string } | null;
 }
 
-export async function getBoardMembers(locale: string): Promise<BoardMember[]> {
-  const res = await fetch(
-    `${BASE_URL}/api/board-members?populate=image&locale=${locale}&sort=id:asc&pagination[pageSize]=100`,
-    { next: { revalidate: 0 } }
-  );
+// Strapi caps pageSize at 100. Board members accumulate per term (~18/term),
+// so a single page would silently drop the newest term once the roster passes
+// 100 — page through all of them instead.
+const BOARD_PAGE_SIZE = 100;
 
-  if (!res.ok) return [];
+function boardMembersUrl(locale: string, page: number): string {
+  return `${BASE_URL}/api/board-members?populate=image&locale=${locale}&sort=id:asc&pagination[pageSize]=${BOARD_PAGE_SIZE}&pagination[page]=${page}`;
+}
 
-  const json = await res.json();
-
-  return json.data.map((item: any) => ({
+function mapBoardMember(item: any): BoardMember {
+  return {
     id: item.id,
     name: item.name,
     role: item.role,
@@ -29,7 +29,29 @@ export async function getBoardMembers(locale: string): Promise<BoardMember[]> {
     image: item.image
       ? { url: item.image.url.startsWith("http") ? item.image.url : `${BASE_URL}${item.image.url}` }
       : null,
-  }));
+  };
+}
+
+export async function getBoardMembers(locale: string): Promise<BoardMember[]> {
+  const first = await fetch(boardMembersUrl(locale, 1), { next: { revalidate: 0 } });
+  if (!first.ok) return [];
+
+  const json = await first.json();
+  const items: any[] = [...json.data];
+
+  const pageCount: number = json.meta?.pagination?.pageCount ?? 1;
+  if (pageCount > 1) {
+    const rest = await Promise.all(
+      Array.from({ length: pageCount - 1 }, (_, i) =>
+        fetch(boardMembersUrl(locale, i + 2), { next: { revalidate: 0 } }).then((res) =>
+          res.ok ? res.json().then((j) => j.data as any[]) : []
+        )
+      )
+    );
+    for (const page of rest) items.push(...page);
+  }
+
+  return items.map(mapBoardMember);
 }
 
 export interface Milestone {


### PR DESCRIPTION
Closes #49 

## ปัญหา
`getBoardMembers()` ใน `lib/about-data.ts` ดึงหน้าเดียวด้วย `pagination[pageSize]=100`
Strapi จำกัด pageSize สูงสุดที่ 100 (ขยายเลขเฉยๆ ไม่ได้) และข้อมูลกรรมการสะสม
per-term ~18 คน/วาระ พอเกิน ~5 วาระจะทะลุ 100 และเพราะ `sort=id:asc`
หน้าแรกจะเป็นข้อมูลเก่า → **วาระใหม่สุดโดนตัดหายจาก dropdown แบบเงียบๆ**
ซึ่งเป็นอาการที่งงที่สุดพอดี

## การแก้
- ดึงหน้าแรกก่อน อ่าน `meta.pagination.pageCount` แล้วไล่ดึงหน้าที่เหลือแบบขนาน
  (`Promise.all`) ต่อกันครบทุกหน้า
- แยก `mapBoardMember()` / `boardMembersUrl()` เป็น helper ลดโค้ดซ้ำ
- คง `sort=id:asc` ไว้ ลำดับการ์ดเลยคงเดิม (นายก → อุปนายก → …) ข้ามหน้าก็ยังเรียงถูก

## ทดสอบ
- `tsc --noEmit` ผ่าน
- จำลอง `pageSize=5` ยิง API จริง → ไล่ครบ 4 หน้า เก็บ 18 คน ไม่ซ้ำ เรียงถูก
  ตรงกับ ground-truth (`pageSize=100`)
- หน้า `/th/about` จริง: HTTP 200 รูปกรรมการครบ 18

## ความเร่งด่วน
ต่ำ — ยังไม่กระทบจนกว่าจะมีข้อมูลเกิน ~5 วาระ (ตอนนี้มีวาระเดียว)
แก้ไว้ก่อนตอน historical import เข้ามาจะได้ไม่เจอของหาย