### PR TITLE
fix(data): guard Strapi media URLs against double-prefixing on Cloud

### DIFF
--- a/lib/archive-data.ts
+++ b/lib/archive-data.ts
@@ -3,6 +3,7 @@ import {
   industryJournals,
   type ResourceItem,
 } from "@/lib/resource-detail-data";
+import { absoluteMediaUrl } from "@/lib/strapi-media";
 
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(
   /\/+$/,
@@ -45,7 +46,7 @@ export async function getArchiveItems(locale: string): Promise<ArchiveGroups> {
   for (const item of items) {
     const link =
       typeof item.link === "string" && item.link.trim() ? item.link.trim() : null;
-    const href = item.file?.url ? `${BASE_URL}${item.file.url}` : link;
+    const href = item.file?.url ? absoluteMediaUrl(item.file.url) : link;
     if (!href) continue; // skip rows with neither a file nor a link
 
     const mapped: ResourceItem = {

--- a/lib/documents-data.ts
+++ b/lib/documents-data.ts
@@ -2,6 +2,7 @@ import {
   associationDocuments,
   type ResourceItem,
 } from "@/lib/resource-detail-data";
+import { absoluteMediaUrl } from "@/lib/strapi-media";
 
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(
   /\/+$/,
@@ -38,7 +39,7 @@ export async function getAssociationDocuments(
   for (const item of items) {
     const link =
       typeof item.link === "string" && item.link.trim() ? item.link.trim() : null;
-    const href = item.file?.url ? `${BASE_URL}${item.file.url}` : link;
+    const href = item.file?.url ? absoluteMediaUrl(item.file.url) : link;
     if (!href) continue;
     mapped.push({ title: item.title || "", href, external: true });
   }

--- a/lib/membership-data.ts
+++ b/lib/membership-data.ts
@@ -1,3 +1,5 @@
+import { absoluteMediaUrl } from "@/lib/strapi-media";
+
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
 
 export interface Benefit {
@@ -87,7 +89,7 @@ export async function fetchHowToJoins(locale: string): Promise<HowtoJoin[]> {
       title: item.title || "",
       description: item.description || "",
       order: item.order ?? 0,
-      iconUrl: item.icon?.url ? `${BASE_URL}${item.icon.url}` : null,
+      iconUrl: item.icon?.url ? absoluteMediaUrl(item.icon.url) : null,
     }))
     .sort((a: HowtoJoin, b: HowtoJoin) => a.order - b.order);
 }
@@ -102,7 +104,7 @@ export async function fetchMemberTypes(locale: string): Promise<MemberType[]> {
     eligibility: item.eligibility || "",
     membership_fee: item.membership_fee ?? null,
     entrance_fee: item.entrance_fee ?? null,
-    iconUrl: item.icon?.url ? `${BASE_URL}${item.icon.url}` : null,
+    iconUrl: item.icon?.url ? absoluteMediaUrl(item.icon.url) : null,
   }));
 }
 
@@ -154,7 +156,7 @@ export async function fetchMembershipDocuments(locale: string): Promise<Membersh
         key: item.key ?? null,
         title: item.title || "",
         order: item.order ?? 0,
-        fileUrl: item.file?.url ? `${BASE_URL}${item.file.url}` : link,
+        fileUrl: item.file?.url ? absoluteMediaUrl(item.file.url) : link,
       };
     })
     .filter((d: MembershipDocument) => d.fileUrl) // hide rows without a file/link

--- a/lib/strapi-media.ts
+++ b/lib/strapi-media.ts
@@ -1,0 +1,8 @@
+const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
+
+// Strapi returns media URLs relative on a local/self-hosted instance
+// (/uploads/…) but absolute on Strapi Cloud (https://…). Prefix the base URL
+// only when the URL isn't already absolute, otherwise a Cloud URL gets doubled.
+export function absoluteMediaUrl(url: string): string {
+  return url.startsWith("http") ? url : `${BASE_URL}${url}`;
+}


### PR DESCRIPTION
Closes #50 

## ปัญหา
`archive-data.ts`, `documents-data.ts`, `membership-data.ts` ต่อ `${BASE_URL}${url}`
เข้ากับ media URL แบบ**ไม่เช็คว่า absolute อยู่แล้วหรือยัง** — บน local Strapi
(คืน URL relative `/uploads/…`) ใช้ได้ปกติ แต่บน Strapi Cloud (คืน absolute
`https://…`) จะได้ host ซ้อนกันเป็น URL พัง เช่น `localhost:1337https://…`
ตรงกับ known bug ที่เคยเจอตอน archive PR

จุดที่มีบั๊ก (5 จุด):
- `lib/archive-data.ts` (href ไฟล์)
- `lib/documents-data.ts` (href ไฟล์)
- `lib/membership-data.ts` (iconUrl ×2, fileUrl ×1)

## การแก้
- เพิ่ม helper กลาง `lib/strapi-media.ts` → `absoluteMediaUrl(url)` ที่เช็ค
  `startsWith("http")` ก่อนต่อ base URL
- แทน pattern เดิมทั้ง 5 จุดด้วย helper

## ขอบเขต
- **ไม่แตะ** `${BASE_URL}${endpoint}` (เป็น URL ของ API ไม่ใช่ media)
- **ไม่แตะ** `about-data.ts` — มี guard เดียวกันถูกอยู่แล้ว และบรรทัดนั้นกำลังถูกแก้
  ใน branch `fix/fetch-board-mem` (เลี่ยง merge conflict) ไว้เปลี่ยนมาใช้ helper
  เป็น follow-up เล็กๆ หลัง branch นั้น merge

## ทดสอบ
- `tsc --noEmit` ผ่าน
- grep ยืนยันไม่มี pattern บั๊กเหลือ (เหลือแค่ about-data ที่ guard อยู่แล้ว)
- หน้า membership / resources / documents / archive: HTTP 200
- ตรวจ URL จริงบนหน้า membership: `http://localhost:1337/uploads/….pdf` ถูกต้อง
  และไม่มี URL ซ้อน (`localhost:1337https://…`)