### PR TITLE
fix(contact): remove redundant hardcoded social links block (#48)

### DIFF
--- a/app/[locale]/(site)/contact/page.tsx
+++ b/app/[locale]/(site)/contact/page.tsx
@@ -3,19 +3,9 @@ import type { Locale } from "@/lib/i18n";
 import { notFound } from "next/navigation";
 import { PageHeader } from "@/components/page-header";
 import { Card, CardContent } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 import { ContactForm } from "@/components/contact-form";
 import { getContact } from "@/lib/contact-data";
-import {
-  MapPin,
-  Mail,
-  Phone,
-  Clock,
-  Facebook,
-  Twitter,
-  Linkedin,
-  Globe,
-} from "lucide-react";
+import { MapPin, Mail, Phone, Clock } from "lucide-react";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -75,13 +65,6 @@ export default async function ContactPage({ params }: PageProps) {
       text: officeHours,
       color: "bg-primary/10 text-primary",
     },
-  ];
-
-  const socialLinks = [
-    { icon: Facebook, label: "Facebook", href: "https://facebook.com/ecti" },
-    { icon: Twitter, label: "X (Twitter)", href: "https://x.com/ecti" },
-    { icon: Linkedin, label: "LinkedIn", href: "https://linkedin.com/company/ecti" },
-    { icon: Globe, label: "ecti.or.th", href: "https://ecti.or.th" },
   ];
 
   return (
@@ -208,29 +191,6 @@ export default async function ContactPage({ params }: PageProps) {
                 </svg>
               </CardContent>
             </Card>
-          </div>
-        </section>
-
-        <Separator className="mb-16" />
-
-        {/* --- Social Links Block --- */}
-        <section className="text-center">
-          <h2 className="mb-6 text-2xl font-bold text-foreground">
-            {dict.contact.socialTitle}
-          </h2>
-          <div className="flex flex-wrap items-center justify-center gap-4">
-            {socialLinks.map((link) => (
-              <a
-                key={link.label}
-                href={link.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-3 rounded-lg border border-border bg-card px-5 py-3 text-sm font-medium text-foreground transition-all hover:border-primary/30 hover:bg-primary/5 hover:shadow-md"
-              >
-                <link.icon className="h-5 w-5 text-primary" />
-                {link.label}
-              </a>
-            ))}
           </div>
         </section>
       </div>


### PR DESCRIPTION
Closes #48

## ปัญหา
ท้ายหน้า contact มีบล็อก "follow us" ที่ **hardcode URL ปลอม**
(`facebook.com/ecti`, `x.com/ecti`, `linkedin.com/company/ecti`, `ecti.or.th`)
ซึ่ง:
- **ซ้ำซ้อนกับ footer** ที่โชว์ social links อยู่ทุกหน้าอยู่แล้ว
- ข้อมูล**ผิด** (footer ดึงจาก Strapi จริงผ่าน `getSocialLinks`)

## การแก้
ตัดบล็อก social ท้ายหน้าออกทั้งหมด (แนวทาง "ตัด...ออก" ตาม issue)
- ลบ `<section>` social + `<Separator>` ที่ค้าง + array `socialLinks`
- เก็บกวาด import ที่ไม่ใช้แล้ว: `Facebook`, `Twitter`, `Linkedin`, `Globe`, `Separator`

แตะไฟล์เดียว: `app/[locale]/(site)/contact/page.tsx`

## ทดสอบ
- `tsc --noEmit` ผ่าน, ไม่มี ref ค้าง
- `/th/contact`: HTTP 200 — URL ปลอมหายแล้ว, ฟอร์ม + การ์ดข้อมูล + map ยังครบ
- footer ยังโชว์ social links จริงเหมือนเดิม

## หมายเหตุ
dict key `contact.socialTitle` ไม่มีใครใช้แล้ว แต่เว้นไว้ให้ diff โฟกัสที่หน้า contact
(unused key ไม่กระทบอะไร) — ลบทีหลังได้ถ้าต้องการ