### PR TITLE
chore(home): change Academic Awards card to Community Service in What we do

### DIFF
--- a/components/activities-section.tsx
+++ b/components/activities-section.tsx
@@ -1,4 +1,4 @@
-import { Presentation, BookOpen, Network, Award } from "lucide-react";
+import { Presentation, BookOpen, Network, HandHeart } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import type { Dictionary } from "@/lib/i18n";
 
@@ -27,7 +27,7 @@ export function ActivitiesSection({ dict }: ActivitiesSectionProps) {
       color: "bg-primary/10 text-primary",
     },
     {
-      icon: Award,
+      icon: HandHeart,
       title: dict.home.activityAward,
       description: dict.home.activityAwardDesc,
       color: "bg-accent/10 text-accent",

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -69,8 +69,8 @@ const dictionaries = {
       activityNetwork: "เครือข่ายวิชาการ",
       activityNetworkDesc:
         "สร้างเครือข่ายความร่วมมือระหว่างนักวิจัย อาจารย์ และภาคอุตสาหกรรม",
-      activityAward: "รางวัลวิชาการ",
-      activityAwardDesc: "มอบรางวัลเพื่อยกย่องผลงานวิจัยและนักวิจัยดีเด่น",
+      activityAward: "งานบริการสังคม",
+      activityAwardDesc: "ให้บริการวิชาการและองค์ความรู้แก่สังคม ชุมชน และภาคอุตสาหกรรม",
       // Featured event
       sectionFeaturedEvent: "กิจกรรมเด่น",
       featuredEventTitle: "ECTI-CON 2026",
@@ -383,9 +383,9 @@ const dictionaries = {
       activityNetwork: "Academic Network",
       activityNetworkDesc:
         "Building collaborative networks among researchers, educators, and industry.",
-      activityAward: "Academic Awards",
+      activityAward: "Community Service",
       activityAwardDesc:
-        "Recognizing outstanding research contributions and researchers.",
+        "Providing academic services and knowledge to society and industry.",
       // Featured event
       sectionFeaturedEvent: "Featured Event",
       featuredEventTitle: "ECTI-CON 2026",


### PR DESCRIPTION
## สรุป
แก้การ์ดที่ 4 ในส่วน "สิ่งที่เราทำ (What we do)" หน้า Home จาก "รางวัลวิชาการ" เป็น "งานบริการสังคม"

Closes #57

## รายละเอียดการเปลี่ยนแปลง
| จุด | เดิม | ใหม่ |
|---|---|---|
| หัวข้อ (ไทย) | รางวัลวิชาการ | งานบริการสังคม |
| คำอธิบาย (ไทย) | มอบรางวัลเพื่อยกย่องผลงานวิจัยและนักวิจัยดีเด่น | ให้บริการวิชาการและองค์ความรู้แก่สังคม ชุมชน และภาคอุตสาหกรรม |
| หัวข้อ (อังกฤษ) | Academic Awards | Community Service |
| คำอธิบาย (อังกฤษ) | Recognizing outstanding research contributions and researchers. | Providing academic services and knowledge to society and industry. |
| ไอคอน | Award (ถ้วยรางวัล) | HandHeart |

## ไฟล์ที่แก้
- `lib/i18n.ts` — ข้อความทั้งภาษาไทยและอังกฤษ
- `components/activities-section.tsx` — เปลี่ยนไอคอน

## การทดสอบ
- `npx tsc --noEmit` ผ่าน (exit 0)