### PR TITLE
feat(news): add cover/in-body images, PDF attachments, and locale fallback

### DIFF
--- a/app/[locale]/(site)/news/[slug]/page.tsx
+++ b/app/[locale]/(site)/news/[slug]/page.tsx
@@ -14,6 +14,8 @@ import {
   User,
   CalendarDays,
   Tag,
+  FileText,
+  Download,
 } from "lucide-react";
 import {
   getNewsPosts,
@@ -90,13 +92,15 @@ export default async function NewsDetailPage({ params }: PageProps) {
 
         <div className="mt-6 grid gap-8 lg:grid-cols-3">
           <article className="lg:col-span-2">
-            <div className="mb-6 flex flex-wrap items-center gap-2">
-              {post.tags.map((tag) => (
-                <Badge key={tag} variant="outline" className={`text-xs font-medium ${getTagStyle(tag)}`}>
-                  {getTagLabel(tag, dict)}
-                </Badge>
-              ))}
-            </div>
+            {post.coverImage && (
+              <div className="mb-8 aspect-video w-full overflow-hidden rounded-lg border border-border bg-muted">
+                <img
+                  src={post.coverImage}
+                  alt={title}
+                  className="h-full w-full object-cover"
+                />
+              </div>
+            )}
 
             <div className="mb-8 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-muted-foreground">
               <span className="flex items-center gap-1.5">
@@ -118,6 +122,38 @@ export default async function NewsDetailPage({ params }: PageProps) {
             <div className="prose prose-sm max-w-none">
               <RichTextRenderer blocks={body} />
             </div>
+
+            {post.attachments.length > 0 && (
+              <div className="mt-10">
+                <h2 className="mb-4 text-lg font-semibold text-foreground">
+                  {dict.news.attachmentsTitle}
+                </h2>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {post.attachments.map((doc) => (
+                    <a
+                      key={doc.id}
+                      href={doc.fileUrl ?? "#"}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="group flex items-center gap-3 rounded-lg border border-border bg-card p-4 transition-shadow hover:shadow-md"
+                    >
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                        <FileText className="h-5 w-5 text-primary" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate font-medium text-foreground">
+                          {doc.title}
+                        </div>
+                        <div className="flex items-center gap-1 text-xs text-primary">
+                          <Download className="h-3 w-3" />
+                          {dict.news.attachmentsDownload}
+                        </div>
+                      </div>
+                    </a>
+                  ))}
+                </div>
+              </div>
+            )}
 
             <Separator className="my-8" />
 

--- a/components/news-card.tsx
+++ b/components/news-card.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, Clock, Tag, User } from "lucide-react";
+import { ArrowRight, Clock, Newspaper, Tag, User } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import type { NewsPost, NewsTag } from "@/lib/news-data";
@@ -51,7 +51,27 @@ export function NewsCard({
     : "";
 
   return (
-    <Card className="group flex flex-col border-border transition-shadow hover:shadow-lg">
+    <Card className="group flex flex-col gap-0 overflow-hidden border-border pt-0 transition-shadow hover:shadow-lg">
+      {/* Cover image (or branded placeholder when a post has none) */}
+      <Link
+        href={`/${locale}/news/${post.slug}`}
+        className="relative block aspect-video w-full overflow-hidden bg-muted"
+        aria-label={title}
+      >
+        {post.coverImage ? (
+          <img
+            src={post.coverImage}
+            alt={title}
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/10 to-accent/10">
+            <Newspaper className="h-9 w-9 text-primary/30" />
+          </div>
+        )}
+      </Link>
+
       <CardContent className="flex flex-1 flex-col gap-3 p-5">
         {/* Tags */}
         <div className="flex flex-wrap items-center gap-1.5">

--- a/components/news-list-client.tsx
+++ b/components/news-list-client.tsx
@@ -228,8 +228,9 @@ export function NewsListSkeleton() {
       </div>
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {[1, 2, 3, 4, 5, 6].map((i) => (
-          <div key={i} className="rounded-lg border border-border p-5">
-            <div className="flex flex-col gap-3">
+          <div key={i} className="overflow-hidden rounded-lg border border-border">
+            <Skeleton className="aspect-video w-full rounded-none" />
+            <div className="flex flex-col gap-3 p-5">
               <div className="flex gap-2">
                 <Skeleton className="h-5 w-20 rounded-full" />
                 <Skeleton className="h-5 w-16 rounded-full" />

--- a/components/rich-text-renderer.tsx
+++ b/components/rich-text-renderer.tsx
@@ -1,6 +1,8 @@
 // Renders Strapi rich-text "blocks" (the array of { type, children } nodes
 // produced by the blocks field) into styled React elements.
 
+import { absoluteMediaUrl } from "@/lib/strapi-media";
+
 // Recursive child node renderer
 function RenderChild({ child }: { child: any }) {
   if (child.type === "link") {
@@ -80,6 +82,25 @@ export function RichTextRenderer({ blocks }: { blocks: any[] }) {
                 ))}
               </blockquote>
             );
+          case "image": {
+            const img = block.image;
+            if (!img?.url) return null;
+            return (
+              <figure key={i} className="my-6">
+                <img
+                  src={absoluteMediaUrl(img.url)}
+                  alt={img.alternativeText || ""}
+                  loading="lazy"
+                  className="mx-auto h-auto max-w-full rounded-lg border border-border"
+                />
+                {img.caption && (
+                  <figcaption className="mt-2 text-center text-xs text-muted-foreground">
+                    {img.caption}
+                  </figcaption>
+                )}
+              </figure>
+            );
+          }
           default:
             return null;
         }

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -231,6 +231,8 @@ const dictionaries = {
       author: "ผู้เขียน",
       backToNews: "กลับไปหน้าข่าวสาร",
       minRead: "นาทีอ่าน",
+      attachmentsTitle: "เอกสารแนบ",
+      attachmentsDownload: "ดาวน์โหลด",
     },
     about: {
       title: "เกี่ยวกับ ECTI",
@@ -548,6 +550,8 @@ const dictionaries = {
       author: "Author",
       backToNews: "Back to News",
       minRead: "min read",
+      attachmentsTitle: "Attachments",
+      attachmentsDownload: "Download",
     },
     about: {
       title: "About ECTI",

--- a/lib/news-data.ts
+++ b/lib/news-data.ts
@@ -1,3 +1,6 @@
+import { absoluteMediaUrl } from "@/lib/strapi-media";
+import { locales } from "@/lib/i18n";
+
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
 
 export const NEWS_TAGS = [
@@ -18,6 +21,12 @@ function toNewsTags(raw: any): NewsTag[] {
     .filter((key: any): key is NewsTag => NEWS_TAGS.includes(key));
 }
 
+export interface NewsAttachment {
+  id: number;
+  title: string;
+  fileUrl: string | null; // uploaded file URL, or the external link fallback
+}
+
 export interface NewsPost {
   id: number;
   slug: string;
@@ -28,39 +37,11 @@ export interface NewsPost {
   tags: NewsTag[];
   author?: string;
   readTimeMin: number;
+  coverImage: string | null; // resolved absolute URL, or null when unset
+  attachments: NewsAttachment[]; // downloadable files; only populated on the detail fetch
 }
 
-export async function getNewsPosts(locale: string): Promise<NewsPost[]> {
-  const res = await fetch(
-    `${BASE_URL}/api/news-posts?populate=tags&sort=publishedAt:desc&locale=${locale}`,
-    { next: { revalidate: 3600 } }
-  );
-  if (!res.ok) return [];
-  const json = await res.json();
-  return json.data
-    .filter((item: any) => item.slug) // skip entries with no slug (e.g. missing localization)
-    .map((item: any) => ({
-      id: item.id,
-      slug: item.slug,
-      title: item.title ?? "",
-      summary: item.summary ?? "",
-      body: item.body ?? [],
-      date: item.publishedAt ?? item.createdAt ?? item.date ?? "",
-      tags: toNewsTags(item.tags),
-      author: item.author ?? undefined,
-      readTimeMin: item.read_time_min ?? 1,
-    }));
-}
-
-export async function getNewsPostBySlug(slug: string, locale: string): Promise<NewsPost | undefined> {
-  const res = await fetch(
-    `${BASE_URL}/api/news-posts?filters[slug][$eq]=${slug}&populate=tags&locale=${locale}`,
-    { next: { revalidate: 3600 } }
-  );
-  if (!res.ok) return undefined;
-  const json = await res.json();
-  if (!json.data?.length) return undefined;
-  const item = json.data[0];
+function mapNewsPost(item: any): NewsPost {
   return {
     id: item.id,
     slug: item.slug,
@@ -71,7 +52,77 @@ export async function getNewsPostBySlug(slug: string, locale: string): Promise<N
     tags: toNewsTags(item.tags),
     author: item.author ?? undefined,
     readTimeMin: item.read_time_min ?? 1,
+    coverImage: item.cover_image?.url ? absoluteMediaUrl(item.cover_image.url) : null,
+    attachments: (item.attachments ?? [])
+      .map((att: any) => ({
+        id: att.id,
+        title: att.title ?? "",
+        // Prefer the uploaded file (Strapi media), fall back to an external link.
+        fileUrl: att.file?.url
+          ? absoluteMediaUrl(att.file.url)
+          : (typeof att.link === "string" && att.link.trim() ? att.link.trim() : null),
+      }))
+      .filter((a: NewsAttachment) => a.fileUrl), // hide rows with neither file nor link
   };
+}
+
+// A published post can exist in only some locales (ECTI news is often authored in
+// a single language). Fetch one locale's rows; callers merge across locales so a
+// post never disappears / 404s just because it wasn't translated.
+async function fetchNewsRows(locale: string): Promise<any[]> {
+  const res = await fetch(
+    `${BASE_URL}/api/news-posts?populate[tags]=true&populate[cover_image]=true&sort=publishedAt:desc&locale=${locale}`,
+    { next: { revalidate: 3600 } }
+  );
+  if (!res.ok) return [];
+  const json = await res.json();
+  return (json.data ?? []).filter((item: any) => item.slug); // skip entries with no slug
+}
+
+// Same post shares a documentId across locales (and the slug is non-localized too).
+function postKey(item: any): string {
+  return item.documentId ?? item.slug;
+}
+
+export async function getNewsPosts(locale: string): Promise<NewsPost[]> {
+  // Prefer the requested locale, then add posts that only exist in another locale.
+  const primary = await fetchNewsRows(locale);
+  const seen = new Set(primary.map(postKey));
+
+  const otherLocales = locales.filter((l) => l !== locale);
+  const fallbackRows = (await Promise.all(otherLocales.map(fetchNewsRows))).flat();
+
+  const merged = [...primary];
+  for (const row of fallbackRows) {
+    const key = postKey(row);
+    if (!seen.has(key)) {
+      seen.add(key);
+      merged.push(row);
+    }
+  }
+
+  return merged
+    .sort(
+      (a, b) =>
+        new Date(b.publishedAt ?? b.createdAt ?? 0).getTime() -
+        new Date(a.publishedAt ?? a.createdAt ?? 0).getTime()
+    )
+    .map(mapNewsPost);
+}
+
+export async function getNewsPostBySlug(slug: string, locale: string): Promise<NewsPost | undefined> {
+  // Try the requested locale first, then fall back to any locale that has the post.
+  const tryLocales = [locale, ...locales.filter((l) => l !== locale)];
+  for (const loc of tryLocales) {
+    const res = await fetch(
+      `${BASE_URL}/api/news-posts?filters[slug][$eq]=${slug}&populate[tags]=true&populate[cover_image]=true&populate[attachments][populate][file]=true&locale=${loc}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) continue;
+    const json = await res.json();
+    if (json.data?.length) return mapNewsPost(json.data[0]);
+  }
+  return undefined;
 }
 
 export async function getRelatedPosts(


### PR DESCRIPTION
## สรุป
เพิ่มรูปให้หน้าข่าว (ปกการ์ด + hero + รูปในเนื้อหา), การ์ดดาวน์โหลดเอกสารแนบ, และ fallback ภาษาเพื่อไม่ให้ข่าวภาษาเดียว 404

## การเปลี่ยนแปลง
- **`lib/news-data.ts`** — ดึง `cover_image` + `attachments`; รวม map เป็น helper เดียว; ใช้ `absoluteMediaUrl` ร่วมทั้งโปรเจกต์; fallback ข้ามภาษา (list = merge ทุก locale + dedup ด้วย documentId, detail = ลอง locale อื่นถ้า locale ที่ขอไม่เจอ)
- **`components/news-card.tsx`** — รูป cover บนการ์ด + fallback placeholder (gradient + ไอคอน) เมื่อข่าวไม่มีรูป
- **`app/[locale]/(site)/news/[slug]/page.tsx`** — hero cover บนหัวบทความ + section "เอกสารแนบ" (การ์ดดาวน์โหลด) + ย้าย tag ไปไว้แถบข้างอย่างเดียว (ตัดที่ซ้ำใต้รูป)
- **`components/rich-text-renderer.tsx`** — render block `image` (รูปแทรกในเนื้อหา) + caption
- **`components/news-list-client.tsx`** — skeleton เพิ่มช่องรูปให้ตรง layout ใหม่
- **`lib/i18n.ts`** — label `เอกสารแนบ` / `ดาวน์โหลด` (th/en)

## พฤติกรรมที่ตั้งใจ
- ข่าวที่มีภาษาเดียว → โผล่ใน list ทั้ง th/en และสลับภาษาแล้วไม่ 404 (เห็นเนื้อหาภาษาต้นฉบับ)
- หน้า list ไม่โชว์ attachments (โชว์เฉพาะในหน้าข่าว)

## วิธีเทสต์
1. เพิ่ม cover_image / รูปในเนื้อหา / attachment ให้ข่าวใน Strapi แล้ว publish
2. หน้า list → เห็นรูปปกบนการ์ด (ไม่มีรูป = placeholder)
3. หน้าข่าว → เห็น hero, รูปในเนื้อหา, การ์ดดาวน์โหลดล่างบทความ
4. ข่าวภาษาเดียว → สลับภาษาไม่ 404

## ขึ้นกับ
- schema `attachments` จาก PR `feat/news-attachments` (ECTI-cms) — ถ้ายังไม่มี field, section เอกสารแนบจะซ่อนเอง front ไม่พัง

close #62 