### PR TITLE
refactor(news): remove cover hero from article detail; cover is card preview only

### DIFF
--- a/app/[locale]/(site)/news/[slug]/page.tsx
+++ b/app/[locale]/(site)/news/[slug]/page.tsx
@@ -92,16 +92,7 @@ export default async function NewsDetailPage({ params }: PageProps) {
 
         <div className="mt-6 grid gap-8 lg:grid-cols-3">
           <article className="lg:col-span-2">
-            {post.coverImage && (
-              <div className="mb-8 aspect-video w-full overflow-hidden rounded-lg border border-border bg-muted">
-                <img
-                  src={post.coverImage}
-                  alt={title}
-                  className="h-full w-full object-cover"
-                />
-              </div>
-            )}
-
+            {/* Cover image is the card preview only; images inside the article come from the body. */}
             <div className="mb-8 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-muted-foreground">
               <span className="flex items-center gap-1.5">
                 <CalendarDays className="h-4 w-4 text-primary" />


### PR DESCRIPTION
## ที่มา
รูปปกแบบ poster (แนวตั้ง) โชว์เป็น hero ในหน้ารายละเอียดข่าวแล้วดูไม่ดี — crop ขาด หรือมีพื้นเทาขนาบข้าง

## แก้
- เอา hero รูปปกออกจากหน้า detail
- `cover_image` ใช้เป็นรูป preview บนการ์ด (หน้า list) เท่านั้น
- รูปในบทความให้แทรกใน `body` เอา (RichTextRenderer รองรับ block รูปอยู่แล้ว — แสดงเต็มขนาดในเนื้อหา)

## ผลหน้า detail
เริ่มที่ วันที่/เวลาอ่าน/ผู้เขียน → เนื้อหา (ไม่มี hero ปก)

ต่อยอดจาก PR รูปข่าว (feat/news-images) ที่ merge ไปแล้ว