### PR TITLE
perf(cache): serve site pages as static and rely on the CMS webhook

### DIFF
--- a/app/[locale]/(site)/events/page.tsx
+++ b/app/[locale]/(site)/events/page.tsx
@@ -5,7 +5,19 @@ import { PageHeader } from "@/components/page-header";
 import { EventsListClient } from "@/components/events-list-client";
 import { fetchEventsFromAPI } from "@/lib/events-data";
 
-export const dynamic = "force-dynamic";
+// No `dynamic = "force-dynamic"` here on purpose. It was added in March, when
+// editing the CMS left the site showing old data and opting out of caching was
+// the quickest way to make it move. The webhook in June fixed that properly —
+// Strapi now calls /api/revalidate on publish — so the opt-out only cost us a
+// serverless render per visitor for a page every visitor sees identically.
+//
+// Nothing on this page varies per request: `event_status` is a field the editor
+// sets in Strapi rather than something derived from today's date, and the
+// year/location filtering all happens in EventsListClient. So it renders once
+// and is served as a file until an editor changes something.
+//
+// If events stop updating after a publish, the webhook is what to check.
+// Putting force-dynamic back would hide that, not fix it.
 
 interface PageProps {
   params: Promise<{ locale: string }>;

--- a/app/[locale]/(site)/layout.tsx
+++ b/app/[locale]/(site)/layout.tsx
@@ -1,9 +1,30 @@
 import { notFound } from "next/navigation";
-import { isValidLocale, getDictionary } from "@/lib/i18n";
+import { isValidLocale, getDictionary, locales } from "@/lib/i18n";
 import type { Locale } from "@/lib/i18n";
 import { SiteHeader } from "@/components/site-header";
 import { SiteFooter } from "@/components/site-footer";
 import { BackToTop } from "@/components/back-to-top";
+
+/**
+ * The two locales the site ships, so every page underneath can be prerendered.
+ *
+ * Without this, `[locale]` is a segment Next has no known values for, and a
+ * page it cannot name at build time is a page it cannot build — so every route
+ * under this layout fell back to rendering on demand, whatever each individual
+ * page said about caching. That is why removing `force-dynamic` from the events
+ * page changed nothing on its own: the page was already dynamic, one level up.
+ *
+ * The detail pages were the exception, and the reason why is the same: they
+ * carry their own generateStaticParams returning locale and slug together, so
+ * they were the only routes Next could name.
+ *
+ * With the locales listed, the pages become files served from the CDN and
+ * Strapi's webhook is what replaces them. Adding a locale here is what makes it
+ * buildable; nothing else reads this list.
+ */
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
 
 interface LocaleLayoutProps {
   children: React.ReactNode;

--- a/lib/about-data.ts
+++ b/lib/about-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
 
 export interface BoardMember {
@@ -33,7 +34,7 @@ function mapBoardMember(item: any): BoardMember {
 }
 
 export async function getBoardMembers(locale: string): Promise<BoardMember[]> {
-  const first = await fetch(boardMembersUrl(locale, 1), { next: { revalidate: 3600 } });
+  const first = await fetch(boardMembersUrl(locale, 1), { next: { revalidate: CMS_REVALIDATE_SECONDS } });
   if (!first.ok) return [];
 
   const json = await first.json();
@@ -43,7 +44,7 @@ export async function getBoardMembers(locale: string): Promise<BoardMember[]> {
   if (pageCount > 1) {
     const rest = await Promise.all(
       Array.from({ length: pageCount - 1 }, (_, i) =>
-        fetch(boardMembersUrl(locale, i + 2), { next: { revalidate: 3600 } }).then((res) =>
+        fetch(boardMembersUrl(locale, i + 2), { next: { revalidate: CMS_REVALIDATE_SECONDS } }).then((res) =>
           res.ok ? res.json().then((j) => j.data as any[]) : []
         )
       )
@@ -64,7 +65,7 @@ export interface Milestone {
 export async function getMilestones(locale: string): Promise<Milestone[]> {
   const res = await fetch(
     `${BASE_URL}/api/milestones?sort=year:asc&locale=${locale}`,
-    { next: { revalidate: 3600 } }
+    { next: { revalidate: CMS_REVALIDATE_SECONDS } }
   );
   if (!res.ok) return [];
   const json = await res.json();
@@ -86,7 +87,7 @@ export async function getMissionVisionCards(locale: string): Promise<AboutCard[]
   try {
     const res = await fetch(
       `${BASE_URL}/api/mission-vision?populate=cards&locale=${locale}`,
-      { next: { revalidate: 3600 } }
+      { next: { revalidate: CMS_REVALIDATE_SECONDS } }
     );
     if (!res.ok) return [];
     const json = await res.json();
@@ -112,7 +113,7 @@ export async function getObjectives(locale: string): Promise<ObjectiveItem[]> {
   try {
     const res = await fetch(
       `${BASE_URL}/api/objective?populate=items&locale=${locale}`,
-      { next: { revalidate: 3600 } }
+      { next: { revalidate: CMS_REVALIDATE_SECONDS } }
     );
     if (!res.ok) return [];
     const json = await res.json();

--- a/lib/apply-data.ts
+++ b/lib/apply-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
 
 /**
@@ -8,7 +9,7 @@ const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").re
 export async function getApplyLink(locale: string): Promise<string | null> {
   try {
     const res = await fetch(`${BASE_URL}/api/membership-apply?locale=${locale}`, {
-      next: { revalidate: 3600 },
+      next: { revalidate: CMS_REVALIDATE_SECONDS },
     });
     if (!res.ok) return null;
     const json = await res.json();

--- a/lib/archive-data.ts
+++ b/lib/archive-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 import {
   eMagazines,
   industryJournals,
@@ -17,7 +18,7 @@ export interface ArchiveGroups {
 
 async function fetchAPI(endpoint: string) {
   try {
-    const res = await fetch(`${BASE_URL}${endpoint}`, { next: { revalidate: 3600 } });
+    const res = await fetch(`${BASE_URL}${endpoint}`, { next: { revalidate: CMS_REVALIDATE_SECONDS } });
     if (!res.ok) return null;
     const json = await res.json();
     return json?.data || [];

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,26 @@
+/**
+ * How long a CMS fetch stays in the Data Cache before Next refetches it on its
+ * own, in seconds.
+ *
+ * This is the *fallback*, not the freshness mechanism. Freshness comes from
+ * Strapi's webhook: publishing anything POSTs to /api/revalidate, which drops
+ * the cached pages so the next visitor gets rebuilt HTML. The timer only
+ * matters when that webhook never arrives — a missed delivery, a deploy in
+ * flight, WEBHOOK_SECRET rotated on one side and not the other.
+ *
+ * It used to be an hour, from before the webhook existed. With both running,
+ * every page that gets steady traffic refetched 24 times a day to discover
+ * nothing had changed — real requests against Strapi Cloud's monthly quota,
+ * spent on content that only changes when an editor touches it.
+ *
+ * A day is long enough to stop paying for that and short enough that a dropped
+ * webhook heals by itself overnight instead of stranding a page forever. That
+ * self-healing is why this isn't `false`: with caching off entirely, one lost
+ * webhook means a page serves stale content until someone notices and
+ * redeploys.
+ *
+ * If content stops updating after a publish, this constant is not the problem —
+ * check that the webhook is reaching /api/revalidate. Lowering this back to
+ * 3600 hides that failure rather than fixing it.
+ */
+export const CMS_REVALIDATE_SECONDS = 86_400;

--- a/lib/conferences-data.ts
+++ b/lib/conferences-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
 
 export interface Conference {
@@ -11,7 +12,7 @@ export async function getConferences(locale: string): Promise<Conference[]> {
   try {
     const res = await fetch(
       `${BASE_URL}/api/conferences?sort=order:asc&locale=${locale}`,
-      { next: { revalidate: 3600 } }
+      { next: { revalidate: CMS_REVALIDATE_SECONDS } }
     );
     if (!res.ok) return [];
     const json = await res.json();

--- a/lib/contact-data.ts
+++ b/lib/contact-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
 
 export interface ContactInfo {
@@ -10,7 +11,7 @@ export interface ContactInfo {
 export async function getContact(locale: string): Promise<ContactInfo | null> {
   try {
     const res = await fetch(`${BASE_URL}/api/contact?locale=${locale}`, {
-      next: { revalidate: 3600 },
+      next: { revalidate: CMS_REVALIDATE_SECONDS },
     });
     if (!res.ok) return null;
     const json = await res.json();

--- a/lib/document-guide-data.ts
+++ b/lib/document-guide-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 /**
  * "วิธีใช้" content for Resources → เอกสารของสมาคม — the reimbursement / loan
  * cases and the receipt & mailing info box, migrated from the legacy page
@@ -206,7 +207,7 @@ export const documentGuideFallback: Record<Locale, DocumentGuide> = {
 
 async function fetchAPI(endpoint: string) {
   try {
-    const res = await fetch(`${BASE_URL}${endpoint}`, { next: { revalidate: 3600 } });
+    const res = await fetch(`${BASE_URL}${endpoint}`, { next: { revalidate: CMS_REVALIDATE_SECONDS } });
     if (!res.ok) return null;
     const json = await res.json();
     return json?.data ?? null;

--- a/lib/documents-data.ts
+++ b/lib/documents-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 import {
   associationDocuments,
   type ResourceItem,
@@ -11,7 +12,7 @@ const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").re
 
 async function fetchAPI(endpoint: string) {
   try {
-    const res = await fetch(`${BASE_URL}${endpoint}`, { next: { revalidate: 3600 } });
+    const res = await fetch(`${BASE_URL}${endpoint}`, { next: { revalidate: CMS_REVALIDATE_SECONDS } });
     if (!res.ok) return null;
     const json = await res.json();
     return json?.data || [];

--- a/lib/events-data.ts
+++ b/lib/events-data.ts
@@ -1,7 +1,8 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 export type EventStatus = "open" | "register" | "upcoming" | "finished";
 export type EventType = "conference" | "workshop" | "seminar";
 
-const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "").replace(/\/+$/, "");
+const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
 const API_URL = `${BASE_URL}/api/activities`;
 
 export interface EventDeadline {
@@ -41,7 +42,7 @@ export async function fetchEventBySlug(slug: string, locale: string) {
   try {
     const res = await fetch(
       `${API_URL}?populate=*&filters[slug][$eq]=${slug}&locale=${locale}`,
-      { next: { revalidate: 3600 } }
+      { next: { revalidate: CMS_REVALIDATE_SECONDS } }
     );
     if (!res.ok) return null;
     json = await res.json();
@@ -87,7 +88,7 @@ export async function fetchEventsFromAPI(locale: string): Promise<ECTIEvent[]> {
   try {
     const res = await fetch(
       `${API_URL}?populate=*&sort=event_start_date:desc&locale=${locale}`,
-      { next: { revalidate: 3600 } }
+      { next: { revalidate: CMS_REVALIDATE_SECONDS } }
     );
     if (!res.ok) return [];
     json = await res.json();
@@ -164,7 +165,7 @@ export async function getFeaturedEvents(
   try {
     const res = await fetch(
       `${API_URL}?populate=*&sort=event_start_date:desc&pagination[limit]=${limit}&locale=${locale}`,
-      { next: { revalidate: 3600 } }
+      { next: { revalidate: CMS_REVALIDATE_SECONDS } }
     );
     if (!res.ok) return [];
     json = await res.json();

--- a/lib/membership-data.ts
+++ b/lib/membership-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 import { absoluteMediaUrl } from "@/lib/strapi-media";
 
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
@@ -59,7 +60,7 @@ export interface MembershipDocument {
 async function fetchAPI(endpoint: string) {
   try {
     const res = await fetch(`${BASE_URL}${endpoint}`, {
-      next: { revalidate: 3600 },
+      next: { revalidate: CMS_REVALIDATE_SECONDS },
     });
     if (!res.ok) {
         return null;

--- a/lib/news-data.ts
+++ b/lib/news-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 import { absoluteMediaUrl } from "@/lib/strapi-media";
 import { locales } from "@/lib/i18n";
 
@@ -79,7 +80,7 @@ async function fetchNewsRows(locale: string): Promise<any[]> {
   try {
     const res = await fetch(
       `${BASE_URL}/api/news-posts?populate[tags]=true&populate[cover_image]=true&sort=publishedAt:desc&locale=${locale}`,
-      { next: { revalidate: 3600 } }
+      { next: { revalidate: CMS_REVALIDATE_SECONDS } }
     );
     if (!res.ok) return [];
     const json = await res.json();
@@ -128,7 +129,7 @@ export async function getNewsPostBySlug(slug: string, locale: string): Promise<N
     try {
       const res = await fetch(
         `${BASE_URL}/api/news-posts?filters[slug][$eq]=${slug}&populate[tags]=true&populate[cover_image]=true&populate[attachments][populate][file]=true&locale=${loc}`,
-        { next: { revalidate: 3600 } }
+        { next: { revalidate: CMS_REVALIDATE_SECONDS } }
       );
       if (!res.ok) continue;
       const json = await res.json();

--- a/lib/publications-data.ts
+++ b/lib/publications-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
 
 export interface Journal {
@@ -11,7 +12,7 @@ export async function getJournals(locale: string): Promise<Journal[]> {
   try {
     const res = await fetch(
       `${BASE_URL}/api/journals?sort=order:asc&locale=${locale}`,
-      { next: { revalidate: 3600 } }
+      { next: { revalidate: CMS_REVALIDATE_SECONDS } }
     );
     if (!res.ok) return [];
     const json = await res.json();

--- a/lib/resources-data.ts
+++ b/lib/resources-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
 
 export type Platform = "YouTube" | "LinkedIn" | "Facebook";
@@ -14,7 +15,7 @@ export interface ResourceLink {
 async function fetchAPI(endpoint: string) {
   try {
     const res = await fetch(`${BASE_URL}${endpoint}`, {
-      next: { revalidate: 3600 },
+      next: { revalidate: CMS_REVALIDATE_SECONDS },
     });
     if (!res.ok) {
       return null;

--- a/lib/social-data.ts
+++ b/lib/social-data.ts
@@ -1,3 +1,4 @@
+import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
 const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
 
 export interface SocialLinks {
@@ -23,7 +24,7 @@ function clean(url: unknown): string | null {
 export async function getSocialLinks(locale: string): Promise<SocialLinks> {
   try {
     const res = await fetch(`${BASE_URL}/api/social-link?locale=${locale}`, {
-      next: { revalidate: 3600 },
+      next: { revalidate: CMS_REVALIDATE_SECONDS },
     });
     if (!res.ok) return EMPTY;
     const json = await res.json();


### PR DESCRIPTION
## สิ่งที่เปลี่ยน

สามอย่างที่ต้องทำพร้อมกัน เพราะทำอย่างเดียวไม่มีผลอะไรเลย

1. **เพิ่ม `generateStaticParams` ให้ `[locale]` layout** — ตัวที่กั้นอยู่จริง Next ไม่รู้ว่า locale มีค่าอะไรได้บ้าง เลยสร้างหน้าล่วงหน้าไม่ได้สักหน้า
2. **ลบ `force-dynamic` ออกจาก `events/page.tsx`** — ค้างมาตั้งแต่ มี.ค. ตอนที่ยังไม่มี webhook
3. **TTL 1 ชม. → 24 ชม.** ย้ายไปเป็นค่ากลางที่ `lib/cache.ts` แทนเลข 3600 ที่กระจายอยู่ 20 จุด

พ่วง: แก้ `BASE_URL` ใน `lib/events-data.ts` ที่ fallback เป็น `""` (อีก 14 ไฟล์เป็น localhost หมด)

## ทำไมต้องเปลี่ยน

เว็บสร้าง HTML ใหม่ทุกครั้งที่มีคนเข้า ทั้งที่ทุกคนเห็นเหมือนกันและเนื้อหาเปลี่ยนเฉพาะตอน publish — กิน serverless invocation และเจอ cold start ฟรีๆ

ส่วน TTL 1 ชม. เป็นของที่เหลือจากยุคก่อนมี webhook ตอนนี้เปิดซ้อนกันสองกลไก หน้าที่มีคนเข้าเรื่อยๆ จะ refetch วันละ 24 รอบเพื่อไปพบว่าไม่มีอะไรเปลี่ยน กินโควตา Strapi Cloud จริงๆ

ที่ตั้ง 24 ชม. ไม่ใช่ `false` เพราะถ้าปิดตัวจับเวลาสนิท webhook หลุดไปตัวเดียวหน้านั้นจะค้างของเก่าตลอดกาลจนกว่าจะมีคนสังเกต — 24 ชม. ยาวพอที่จะเลิกจ่ายค่า refetch และสั้นพอที่จะกู้ตัวเองข้ามคืน

Closes #107

## ตรวจสอบยังไง

- [x] `pnpm build` ผ่าน
- [x] ตารางเส้นทางออกมาเป็น **32 หน้า prerendered / 3 หน้า dynamic** และ 3 ตัวนั้นคือ `/api/contact`, `/api/subscribe`, `/api/revalidate` ซึ่งต้องเป็น dynamic
- [x] `npx tsc --noEmit` ผ่าน

ก่อนหน้านี้ตารางเป็น SSG 2 หน้า / dynamic 17 หน้า

> build ในเครื่องต้องมี Strapi ที่ `NEXT_PUBLIC_API_URL` ตอบได้ ไม่งั้นหน้าจะถูก build เป็นหน้าว่าง (ทุก data layer จับ error แล้วคืน `[]`)

## ผลกระทบ

- **Breaking change:** ไม่มีในแง่โค้ด แต่พฤติกรรมเปลี่ยน — ดูหัวข้อล่าง
- **ต้องตั้ง env ใหม่:** ไม่มี
- **ต้องแก้ข้อมูลใน Strapi:** ไม่มี
- **ต้อง deploy พร้อมกันกับอีก repo:** ไม่

### ⚠️ webhook กลายเป็นตัวหลักจริงหลัง PR นี้

เดิมถ้า webhook ไม่ทำงาน ตัวจับเวลา 1 ชม. ยังกลบให้ ตอนนี้ไม่มีแล้ว — **แก้เนื้อหาใน CMS แล้วเว็บจะนิ่งได้ถึง 24 ชม.**

ก่อน merge ควรยืนยันว่า Strapi ยิงถึง `/api/revalidate` จริง:

1. ดู log ตอน Strapi restart ว่ามีบรรทัด `[webhook] WEBHOOK_URL is not set` ไหม
2. แก้ข่าวหนึ่งตัว → publish → เปิดเว็บดูว่าเปลี่ยนไหม

ถ้าข้อ 2 ไม่ผ่าน เปลี่ยน `CMS_REVALIDATE_SECONDS` ใน `lib/cache.ts` กลับเป็น `3600` ชั่วคราวได้ แก้บรรทัดเดียว

### ต้นทุนที่ย้ายที่

ทุก deploy ต้อง build 32 หน้า = ยิง Strapi ครบทุก endpoint (หลัง import ข่าว/งานจะขึ้นเป็นหลักร้อยหน้า) ต้นทุนย้ายจากตอนคนเข้าเว็บไปอยู่ที่ตอน deploy ซึ่งเกิดเดือนละไม่กี่ครั้ง

## Checklist

- [x] commit message เป็นรูปแบบ `<type>(<scope>): <description>`
- [x] ทดสอบทั้ง locale `th` และ `en` — ทั้งสองถูก prerender ครบทุกหน้า
- [x] ไม่มี secret หรือ key หลุดเข้า commit