### PR TITLE
fix(events): read event detail metadata from the CMS, not the examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/app/[locale]/(site)/events/[slug]/page.tsx
+++ b/app/[locale]/(site)/events/[slug]/page.tsx
@@ -19,29 +19,72 @@ import {
   Tag,
   CalendarCheck,
 } from "lucide-react";
-import { events, getEventBySlug, fetchEventBySlug } from "@/lib/events-data";
+import { events, getEventBySlug, fetchEventBySlug, fetchEventsFromAPI } from "@/lib/events-data";
 import type { ECTIEvent, EventStatus } from "@/lib/events-data";
 
 interface PageProps {
   params: Promise<{ locale: string; slug: string }>;
 }
 
+/**
+ * Every event the CMS knows about, in both locales.
+ *
+ * This used to list the six events hard-coded in lib/events-data.ts, which was
+ * fine while those six were all there were. The legacy import put 41 real
+ * conferences in the CMS, and none of them were in that array — so none of them
+ * were prerendered, and the page below quietly fell back to rendering them on
+ * demand while `generateMetadata` returned nothing at all for them.
+ *
+ * The static fallback is still merged in. It is what the page falls back to when
+ * the CMS is unreachable, and dropping its slugs here would mean a build against
+ * a down CMS produces a site where those pages 404 rather than showing the
+ * built-in copy.
+ */
 export async function generateStaticParams() {
-  return events.flatMap((event) => [
-    { locale: "th", slug: event.slug },
-    { locale: "en", slug: event.slug },
+  const fromCms = await fetchEventsFromAPI("th");
+
+  const slugs = new Set([
+    ...fromCms.map((event) => event.slug),
+    ...events.map((event) => event.slug),
+  ]);
+
+  return [...slugs].flatMap((slug) => [
+    { locale: "th", slug },
+    { locale: "en", slug },
   ]);
 }
 
+/**
+ * Reads the same source the page does, in the same order.
+ *
+ * These two disagreeing is the bug this replaces: the page rendered a
+ * conference from the CMS while the tab title, the search result and every
+ * shared link described nothing, because metadata was still looking the slug up
+ * in an array of six examples.
+ */
 export async function generateMetadata({ params }: PageProps) {
   const { locale, slug } = await params;
   if (!isValidLocale(locale)) return {};
-  const event = getEventBySlug(slug);
+
+  const event = (await fetchEventBySlug(slug, locale)) ?? getEventBySlug(slug);
   if (!event) return {};
+
   const dict = getDictionary(locale as Locale);
+  const url = `/${locale}/events/${slug}`;
+
   return {
     title: `${event.title} | ${dict.events.title}`,
     description: event.description,
+    openGraph: {
+      title: event.title,
+      description: event.description,
+      type: "article",
+      locale: locale === "th" ? "th_TH" : "en_US",
+    },
+    alternates: {
+      canonical: url,
+      languages: { th: `/th/events/${slug}`, en: `/en/events/${slug}` },
+    },
   };
 }
 


### PR DESCRIPTION
## สิ่งที่เปลี่ยน

`events/[slug]` มีสองฟังก์ชันที่อ่านคนละแหล่งกับตัวหน้า — แก้ให้อ่านที่เดียวกัน

| | ก่อน | หลัง |
|---|---|---|
| `generateMetadata` | อาร์เรย์ตัวอย่าง 6 รายการ | CMS ก่อน แล้วค่อย fallback |
| `generateStaticParams` | 6 slug | CMS + 6 slug เดิม |
| ตัวหน้า | CMS อยู่แล้ว | เหมือนเดิม |

พ่วง `openGraph` กับ `alternates` ซึ่งหน้าอื่นมีครบหมดแล้วเหลือสองหน้านี้

## ทำไมต้องเปลี่ยน

การ import งานประชุมเก่าเพิ่ง**ใส่ 41 งานจริงเข้า CMS** ซึ่งไม่มีอยู่ในอาร์เรย์ตัวอย่างสักงาน ผลคือ:

- หน้าแสดงผลถูกต้อง แต่ **tab title ว่าง คำอธิบายว่าง และลิงก์ที่แชร์ออกไปไม่บอกอะไรเลย** เพราะ `generateMetadata` คืน `{}`
- ทั้ง 41 งานไม่ถูกสร้างล่วงหน้า — เป็นส่วนเดียวของเว็บที่ยัง render ตอนมีคนขอ หลังจาก #108 ย้ายทุกอย่างไปเป็น static แล้ว

อาร์เรย์ตัวอย่างยังเก็บไว้ ไม่ได้ลบ เพราะเป็น fallback ตอน CMS ล่ม ถ้าตัดออก build ตอน CMS ไม่ตอบจะได้เว็บที่หน้าพวกนั้น 404 แทนที่จะโชว์ของสำรอง

Closes #107 (บางส่วน — ข้อ SEO-4)

## ตรวจสอบยังไง

- [x] `npx tsc --noEmit` ผ่าน
- [x] build กับ stub ที่เสิร์ฟงานประชุม 41 งานที่ import จริง → **94 หน้า (47 งาน × 2 ภาษา)** จากเดิม 12 หน้า
- [x] ตรวจ `<title>` ในไฟล์ที่ build ออกมา → มีชื่องานจากข้อมูล CMS ทุกหน้า

⚠️ ตอน build ในเครื่องต้อง `rm -rf .next/cache` ก่อน ไม่งั้น Data Cache จาก build ก่อน (ตอนนี้ TTL 24 ชม. หลัง #108) จะถูกใช้ซ้ำ และดูเหมือนโค้ดไม่ทำงาน — Vercel build ใหม่เสมอ ไม่มีปัญหานี้

## ผลกระทบ

- **Breaking change:** ไม่มี
- **ต้องตั้ง env ใหม่:** ไม่มี
- **ต้องแก้ข้อมูลใน Strapi:** ไม่มี
- **ต้อง deploy พร้อมกันกับอีก repo:** ไม่ — แต่ **ควร merge ก่อน redeploy ครั้งถัดไป** เพราะ 41 งานเพิ่งเข้า CMS แล้ว การ redeploy ตอนนี้จะสร้าง 82 หน้าที่ไม่มี metadata

## Checklist

- [x] commit message เป็นรูปแบบ `<type>(<scope>): <description>`
- [x] ทดสอบทั้ง locale `th` และ `en`
- [x] ไม่มี secret หรือ key หลุดเข้า commit